### PR TITLE
fix: health check inconsistencies and key ID extraction

### DIFF
--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -9,10 +9,11 @@ pub async fn health_check(
     let mut health_checks = vec![];
 
     // Check key manager health
-    let key_status = match state.key_manager.get_encoded_config().await {
-        Ok(config) if config.len() > 100 => "healthy",
-        Ok(_) => "unhealthy",
-        Err(_) => "unhealthy",
+    let stats = state.key_manager.get_stats().await;
+    let key_status = if stats.active_keys > 0 {
+        "healthy"
+    } else {
+        "unhealthy"
     };
 
     health_checks.push(json!({
@@ -20,31 +21,31 @@ pub async fn health_check(
         "status": key_status
     }));
 
-    // Check backend connectivity - use the correct health endpoint
-    let backend_health_url = format!("{}/health", state.config.backend_url);
-    let backend_status = match state
+    // Check backend connectivity - any HTTP response means reachable
+    let backend_url = state.config.backend_url.clone();
+    let (backend_status, backend_error) = match state
         .http_client
-        .get(&backend_health_url)
+        .head(&backend_url)
         .timeout(Duration::from_secs(5))
         .send()
         .await
     {
-        Ok(resp) if resp.status().is_success() => "healthy",
-        Ok(resp) => {
-            tracing::warn!("Backend health check returned: {}", resp.status());
-            "unhealthy"
-        }
+        Ok(_) => ("healthy", None),
         Err(e) => {
             tracing::error!("Backend health check failed: {}", e);
-            "unhealthy"
+            ("unhealthy", Some(e.to_string()))
         }
     };
 
-    health_checks.push(json!({
+    let mut backend_check = json!({
         "component": "backend",
         "status": backend_status,
-        "url": backend_health_url
-    }));
+        "url": backend_url
+    });
+    if let Some(err) = backend_error {
+        backend_check["error"] = json!(err);
+    }
+    health_checks.push(backend_check);
 
     let overall_status = if health_checks.iter().all(|c| c["status"] == "healthy") {
         "healthy"

--- a/src/handlers/ohttp.rs
+++ b/src/handlers/ohttp.rs
@@ -128,10 +128,10 @@ async fn handle_ohttp_request_inner(
         .map_err(|e| GatewayError::InternalError(format!("Response build error: {e}")))
 }
 
-/// Extract key ID from OHTTP request (first byte after version)
+/// Extract key ID from OHTTP request (first byte per RFC 9458)
 fn extract_key_id_from_request(body: &[u8]) -> Option<u8> {
-    // OHTTP request format: version(1) + key_id(1) + kem_id(2) + kdf_id(2) + aead_id(2) + enc + ciphertext
-    if body.len() > 1 { Some(body[1]) } else { None }
+    // OHTTP request format per RFC 9458: key_id(1) + kem_id(2) + kdf_id(2) + aead_id(2) + enc + ciphertext
+    if !body.is_empty() { Some(body[0]) } else { None }
 }
 
 /// Validate the incoming OHTTP request
@@ -466,7 +466,8 @@ mod tests {
 
     #[test]
     fn test_extract_key_id() {
-        let body = vec![0x00, 0x7F, 0x00, 0x01]; // version, key_id, kem_id...
+        // RFC 9458 format: key_id(1) + kem_id(2) + ...
+        let body = vec![0x7F, 0x00, 0x20, 0x00]; // key_id=0x7F, kem_id=0x0020...
         assert_eq!(extract_key_id_from_request(&body), Some(0x7F));
 
         let empty = vec![];


### PR DESCRIPTION
 ## Summary
  - Fix key ID extraction: Read `body[0]` instead of `body[1]` per RFC 9458 (no version byte in encapsulated request
   format). The old code extracted `0x00` from the KEM ID instead of the actual key ID, causing fallback to the wrong
  server after key rotation and "Failed to open ciphertext" errors.
  - Fix OHTTP key health check: Replace `config.len() > 100` byte-length heuristic with `active_keys > 0` check. A
  typical X25519 config is ~49 bytes, so the old threshold always reported "unhealthy".
  - Fix backend health check: Use `HEAD /` instead of `GET /health`. Any HTTP response means the backend is
  reachable; only connection failures are unhealthy. Includes error details in JSON output.

Fixes https://github.com/gruberb/ohttp-gateway/issues/1