### PR TITLE
Allow overriding target cpu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage
 FROM rust:1.88-slim as builder
 
+ARG RUST_TARGET_CPU=native
+
 WORKDIR /app
 
 # Install build dependencies
@@ -16,14 +18,14 @@ COPY Cargo.toml ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # Build dependencies
-RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
+RUN RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" cargo build --release
 RUN rm -rf src
 
 # Copy source code
 COPY src ./src
 
 # Build the actual application
-RUN touch src/main.rs && RUSTFLAGS="-C target-cpu=native" cargo build --release
+RUN touch src/main.rs && RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" cargo build --release
 
 # Runtime stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
I'm trying to build and run this service on `arm64` CPUs. I'm building this from Github Actions `ubuntu-24.04-arm` runners and running on `ARM64` AWS instances.

The issue I'm having is that those instances exit immediately with the following error code:
```
Task stopped at: 2026-06-23T21:41:38.664Z
Essential container in task exited
1 essential container exited
  [cleanweb-gateway-ecs-task] Exit code: 132.
```

I need to be able to override the `target-cpu` so I can build with correct CPU instructions and run on CPUs that AWS expects (e.g. `neoverse-n1`).